### PR TITLE
Fix update of external line number when cleared

### DIFF
--- a/red_subway_wagon/init.lua
+++ b/red_subway_wagon/init.lua
@@ -191,50 +191,51 @@ local subway_wagon_def = {
 	},
 	custom_on_step = function(self, dtime, data, train)
 		-- Set the line number for the train
-		if tonumber(train.line) then
-			if (tonumber(train.line) <= 9) and (tonumber(train.line) > 0) then
-				if self.livery then
-					self.object:set_properties({
-						textures={
-							self.livery.."^r_line_"..train.line..".png",
-							"r_wagon_interior.png",
-							"r_chassis_accessories.png",
-							"r_coupler.png",
-							"r_wheel_truck.png",
-							"r_wheel_truck.png",
-							"r_coupler.png",
-							"r_doors.png^"..self.door_livery_data,
-							"r_end_doors.png^"..self.end_door_livery_data,
-							"r_glasses.png",
-							"r_seats.png",
-							"r_wheels.png",
-							"r_wheels.png",
-							"r_wheels.png",
-							"r_wheels.png",
-						}
-					})
-				else
-					self.object:set_properties({
-						textures={
-							"r_wagon_exterior.png^r_line_"..train.line..".png",
-							"r_wagon_interior.png",
-							"r_chassis_accessories.png",
-							"r_coupler.png",
-							"r_wheel_truck.png",
-							"r_wheel_truck.png",
-							"r_coupler.png",
-							"r_doors.png",
-							"r_end_doors.png",
-							"r_glasses.png",
-							"r_seats.png",
-							"r_wheels.png",
-							"r_wheels.png",
-							"r_wheels.png",
-							"r_wheels.png",
-						}
-					})
-				end
-			end
+		local line = ""
+		local line_number = tonumber(train.line)
+		if line_number and line_number <= 9 and line_number > 0 then
+			line = "^r_line_"..train.line..".png"
+		end
+		if self.livery then
+			self.object:set_properties({
+				textures={
+					self.livery..line,
+					"r_wagon_interior.png",
+					"r_chassis_accessories.png",
+					"r_coupler.png",
+					"r_wheel_truck.png",
+					"r_wheel_truck.png",
+					"r_coupler.png",
+					"r_doors.png^"..self.door_livery_data,
+					"r_end_doors.png^"..self.end_door_livery_data,
+					"r_glasses.png",
+					"r_seats.png",
+					"r_wheels.png",
+					"r_wheels.png",
+					"r_wheels.png",
+					"r_wheels.png",
+				}
+			})
+		else
+			self.object:set_properties({
+				textures={
+					"r_wagon_exterior.png"..line,
+					"r_wagon_interior.png",
+					"r_chassis_accessories.png",
+					"r_coupler.png",
+					"r_wheel_truck.png",
+					"r_wheel_truck.png",
+					"r_coupler.png",
+					"r_doors.png",
+					"r_end_doors.png",
+					"r_glasses.png",
+					"r_seats.png",
+					"r_wheels.png",
+					"r_wheels.png",
+					"r_wheels.png",
+					"r_wheels.png",
+				}
+			})
 		end
 	end
 }


### PR DESCRIPTION
This fix corrects a minor cosmetic issue that occurs when a player attempts to clear an existing line number value (1-9) of a wagon.  Specifically, clearing the line number field via the onboard computer in the driver's stand does not immediately cause the external display of the line number to be cleared.  It will be cleared eventually if the player triggers a reload of the wagon such as when leaving and then returning to the area of the wagon or by exiting and restarting the game.  This fix causes the external line number to be cleared immediately without needing to trigger a reload of the wagon.