### PR TITLE
Add alias for migration between 1.x and 2.x

### DIFF
--- a/01700_series/init.lua
+++ b/01700_series/init.lua
@@ -144,3 +144,7 @@ local train_def = {
 }
 
 subways.register_subway("01700_series", train_def, "01700 Series", "01700_series_inv.png")
+
+if advtrains.register_wagon_alias then
+    advtrains.register_wagon_alias("red_subway_wagon", "01700_series")
+end

--- a/lrv_type_9/init.lua
+++ b/lrv_type_9/init.lua
@@ -228,3 +228,7 @@ local train_middle_def = {
 
 subways.register_subway("lrv_type_9", train_def, "LRV Type 9", "type_9_inv.png")
 subways.register_subway("lrv_type_9_middle", train_middle_def, "LRV Type 9 Middle Section", "type_9_middle_inv.png")
+
+if advtrains.register_wagon_alias then
+    advtrains.register_wagon_alias("advtrains:green_subway_wagon", "subways_lrv_type_9:lrv_type_9")
+end


### PR DESCRIPTION
This PR adds wagon alias to 01700 series and lrv type 9. This PR requires [Advtrains patch "Alias for wagon types"](https://lists.sr.ht/~gpcf/advtrains-devel/patches/54786), but running with this PR without those changes won't crash the server.

This PR is ready for review.