### PR TITLE
Allow walking into subway trains

### DIFF
--- a/01700_series/init.lua
+++ b/01700_series/init.lua
@@ -130,6 +130,7 @@ local train_def = {
                 driving_ctrl_access = false,
             },
         },
+	    door_entry = { 1.6, -1.6 },
         coupler_types_back = {tomlinson = true},
         coupler_types_front = {tomlinson = true},
         assign_to_seat_group = {"passenger", "driver_stand"},

--- a/lrv_type_9/init.lua
+++ b/lrv_type_9/init.lua
@@ -127,6 +127,7 @@ local train_def = {
                 driving_ctrl_access = false,
             },
         },
+	    door_entry = { 2, -1.7 },
         coupler_types_back = {lrv_type_9 = true},
         coupler_types_front = {tomlinson = true},
         assign_to_seat_group = {"passenger", "driver_stand"},


### PR DESCRIPTION
This PR adds `door_entry` onto wagons so players can walk into them. Players can walk into the train via the driver stand of LRV Type 9 trains because Advtrains does not support asymmetric door entry.