### PR TITLE
Remove unused get_properties() return value

### DIFF
--- a/subways/init.lua
+++ b/subways/init.lua
@@ -183,7 +183,7 @@ function subways.register_subway(name, subway_def, readable_name, inv_image)
         update_textures = function(self, update_text)
 
             -- Used to set the textures
-            local textures = self.object:get_properties().textures
+            local textures
 
             -- The livery
             if self.livery then


### PR DESCRIPTION
This PR cleans the code by not getting current object properties. This also fixes rare errors where self.object:get_properties() is nil.