### PR TITLE
Fix attempt to index local 'old_props'

### DIFF
--- a/subways/init.lua
+++ b/subways/init.lua
@@ -264,7 +264,9 @@ function subways.register_subway(name, subway_def, readable_name, inv_image)
                     end
                 else
                     -- Just use the texture that's already there
-                    textures[display.slot] = old_props.textures[display.slot]
+                    if old_props and old_props.textures then
+                        textures[display.slot] = old_props.textures[display.slot]
+                    end
                 end
             end
 


### PR DESCRIPTION
This fixes the following error:

```
/root/.minetest/mods/subways/subways/init.lua:267: attempt to index local 'old_props' (a nil value)
stack traceback:
	[C]: in function '__index'
	/root/.minetest/mods/subways/subways/init.lua:267: in function 'update_textures'
	/root/.minetest/mods/subways/subways/init.lua:170: in function 'custom_on_velocity_change'
	/root/.minetest/mods/advtrains/advtrains/wagons.lua:627: in function 'func'
	...ocal/share/minetest/builtin/profiler/instrumentation.lua:124: in function 'old_on_step'
	/root/.minetest/mods/monitoring/builtin/on_step.lua:18: in function </root/.minetest/mods/monitoring/builtin/on_step.lua:16>
```